### PR TITLE
Mark 2.7.0 as security release

### DIFF
--- a/_posts/2022-04-25-2_7_0-release.md
+++ b/_posts/2022-04-25-2_7_0-release.md
@@ -1,6 +1,6 @@
 ---
 layout: posts
-title: 2.7.0 Maintenance release
+title: 2.7.0 Maintenance and security release
 date: 2022-04-25
 author: an
 ---


### PR DESCRIPTION
Forgot the security part in header